### PR TITLE
feat : limited to 3cards view in homeview.

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -26,7 +26,7 @@
         <div>더보기  &gt;</div>
       </router-link>
     </div>
-    <RecipePreviewCardContainerVue v-if="bookmarkedRecipes.length" :cardData="bookmarkedRecipes"/>
+    <RecipePreviewCardContainerVue v-if="bookmarkedRecipes.length" :cardData="bookmarkedRecipes.slice(bookmarkedRecipes.length - 3, bookmarkedRecipes.legnth)"/>
     <div v-else class="non-card-view">
       <img src="/images/homeview/non_bookmark_icon.png" class="icon">
       <div class="title">저장한 레시피가 없습니다.</div>
@@ -40,7 +40,7 @@
         <div>더보기  &gt;</div>
       </router-link>
     </div>
-    <RecipePreviewCardContainerVue v-if="myRecipe.length" :cardData="myRecipe"/>
+    <RecipePreviewCardContainerVue v-if="myRecipe.length" :cardData="myRecipe.slice(myRecipe.length - 3, myRecipe.length)"/>
     <div v-else class="non-card-view">
       <img src="/images/homeview/non_myrecipe_icon.png" class="icon">
       <div class="title">등록한 레시피가 없습니다.</div>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -26,7 +26,7 @@
         <div>더보기  &gt;</div>
       </router-link>
     </div>
-    <RecipePreviewCardContainerVue v-if="bookmarkedRecipes.length" :cardData="bookmarkedRecipes.slice(bookmarkedRecipes.length - 3, bookmarkedRecipes.legnth)"/>
+    <RecipePreviewCardContainerVue v-if="bookmarkedRecipes.length" :cardData="bookmarkedRecipes.slice(this.listIndex(bookmarkedRecipes.length - 3), bookmarkedRecipes.legnth)"/>
     <div v-else class="non-card-view">
       <img src="/images/homeview/non_bookmark_icon.png" class="icon">
       <div class="title">저장한 레시피가 없습니다.</div>
@@ -40,7 +40,7 @@
         <div>더보기  &gt;</div>
       </router-link>
     </div>
-    <RecipePreviewCardContainerVue v-if="myRecipe.length" :cardData="myRecipe.slice(myRecipe.length - 3, myRecipe.length)"/>
+    <RecipePreviewCardContainerVue v-if="myRecipe.length" :cardData="myRecipe.slice(this.listIndex(myRecipe.length - 3), myRecipe.length)"/>
     <div v-else class="non-card-view">
       <img src="/images/homeview/non_myrecipe_icon.png" class="icon">
       <div class="title">등록한 레시피가 없습니다.</div>
@@ -82,6 +82,13 @@ export default {
           item.user_id == JSON.parse(localStorage.getItem('user')).username
         )
     },
+    listIndex(index) {
+      if(index < 0) {
+        return 0;
+      } else {
+        return index;
+      }
+    }
   },
   created() {
     this.loadMyRecipe();


### PR DESCRIPTION
## Docs- [Issue Link](https://www.figma.com/design/iuuQhVL95gfnuIx7t3w5Xh/%EC%9A%94%EB%A6%AC-%EB%A0%88%EC%8B%9C%ED%94%BC-%EC%B6%94%EC%B2%9C?node-id=126-893&t=tpbMmgOwWnmoPb7A-1)

## Changes
- before : 카드요소가 4개 이상이면 화면을 이탈하여 카드요소가 생성됨
- after : 카드 요소가 4개 이상이더라도 가장 최신의 카드요소를 반영하여 3개 이하로 줄임.
- images
<img width="278" alt="image" src="https://github.com/user-attachments/assets/de7bd5cb-0fad-4971-bad0-997643736c04">
<img width="278" alt="image" src="https://github.com/user-attachments/assets/61830820-515f-44f5-b315-b85e0d9168b9">

## Review Points

#### Problem
2개일 떄 slice 함수에 들어가는 내용이 음수가 되어서 1개만 출력되는 이슈가 있음.

#### Solution
음수이면 0이 출력되는 함수를 생성하여 해결.

## Test Checklist